### PR TITLE
101 test for action child

### DIFF
--- a/client/actions/children.js
+++ b/client/actions/children.js
@@ -14,7 +14,7 @@ export const requestChildren = () => {
 export const receiveChildren = (children) => {
   return {
     type: RECEIVE_CHILDREN,
-    children: children.map(child => child)
+    children
   }
 }
 

--- a/client/actions/wishes.js
+++ b/client/actions/wishes.js
@@ -14,7 +14,7 @@ export const requestWishes = () => {
 export const receiveWishes = (wishes) => {
   return {
     type: RECEIVE_WISHES,
-    wishes: wishes.map(wish => wish)
+    wishes
   }
 }
 

--- a/tests/client/actions/children.test.js
+++ b/tests/client/actions/children.test.js
@@ -1,15 +1,13 @@
-import { requestChildren,receiveChildren } from '../../../client/actions/children'
+import { requestChildren, receiveChildren } from '../../../client/actions/children'
 
-
-test ('requestChildren creates a correct action', () => {
-    const action = requestChildren()
-    expect(action.type).toBe('REQUEST_CHILDREN')
+test('requestChildren creates a correct action', () => {
+  const action = requestChildren()
+  expect(action.type).toBe('REQUEST_CHILDREN')
 })
 
-test ('receiveChildren creates a correct action', () => {
-    const name = 'test children'
-    const action = receiveChildren(name)
-    expect(action.type).toBe('RECEIVE_CHILDREN')
-    expect(action.children).toBe(name)
+test('receiveChildren creates a correct action', () => {
+  const name = 'test children'
+  const action = receiveChildren(name)
+  expect(action.type).toBe('RECEIVE_CHILDREN')
+  expect(action.children).toBe(name)
 })
-

--- a/tests/client/actions/children.test.js
+++ b/tests/client/actions/children.test.js
@@ -1,0 +1,15 @@
+import { requestChildren,receiveChildren } from '../../../client/actions/children'
+
+
+test ('requestChildren creates a correct action', () => {
+    const action = requestChildren()
+    expect(action.type).toBe('REQUEST_CHILDREN')
+})
+
+test ('receiveChildren creates a correct action', () => {
+    const name = 'test children'
+    const action = receiveChildren(name)
+    expect(action.type).toBe('RECEIVE_CHILDREN')
+    expect(action.children).toBe(name)
+})
+


### PR DESCRIPTION
Hi team,
please review my test for action-child.js
@mxbialostocki  sine i failed to pass, i realized, we do not need to map child in receive _children, we could still get the data by just call children.(call action then return object)
remove .map() 

#101 